### PR TITLE
Better message for DeadlinException.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2020-05-20
+### Changed
+- Deadline exception also contains information how long has passed from the start of the unit of work.
+In servlet case it means from beginning of the request.
+
 ## [0.2.1] - 2020-05-05
 ### Changed
 - Deadline can be now extended. Even when this would be very bad practice, it is sometimes needed during migration and optimization process.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.2.1
+version=0.2.2

--- a/tw-context/src/main/java/com/transferwise/common/context/DeadlineExceededException.java
+++ b/tw-context/src/main/java/com/transferwise/common/context/DeadlineExceededException.java
@@ -1,13 +1,32 @@
 package com.transferwise.common.context;
 
+import com.transferwise.common.baseutils.clock.ClockHolder;
+import java.time.Duration;
 import java.time.Instant;
+import java.util.concurrent.TimeUnit;
 
 public class DeadlineExceededException extends RuntimeException {
 
   static final long serialVersionUID = 1L;
 
+  public DeadlineExceededException(Instant deadline, Instant unitOfWorkCreationTime) {
+    super(createMessage(deadline, unitOfWorkCreationTime));
+  }
+
+  private static String createMessage(Instant deadline, Instant unitOfWorkCreationTime) {
+    long sinceDeadlineExceededMillis = Math.max(0, ClockHolder.getClock().millis() - deadline.toEpochMilli());
+    String formattedDeadline = DurationFormatUtils.formatDuration(Duration.ofMillis(sinceDeadlineExceededMillis));
+    if (unitOfWorkCreationTime == null) {
+      return "Deadline exceeded " + formattedDeadline + " ago.";
+    } else {
+      long durationMillis = Math.max(0, ClockHolder.getClock().millis() - unitOfWorkCreationTime.toEpochMilli());
+      String formattedDuration = DurationFormatUtils.formatDuration(Duration.ofMillis(durationMillis));
+      return "Deadline exceeded " + formattedDeadline + " ago. Time taken in current unit of work was " + formattedDuration + ".";
+    }
+  }
+
   public DeadlineExceededException(Instant deadline) {
-    this("Deadline " + deadline.toEpochMilli() + " exceeded.");
+    this(deadline, null);
   }
 
   public DeadlineExceededException(String message) {

--- a/tw-context/src/main/java/com/transferwise/common/context/DefaultUnitOfWorkManager.java
+++ b/tw-context/src/main/java/com/transferwise/common/context/DefaultUnitOfWorkManager.java
@@ -47,7 +47,7 @@ public class DefaultUnitOfWorkManager implements UnitOfWorkManager {
 
     if (unitOfWork != null && unitOfWork.hasDeadlinePassed()) {
       metricsTemplate.registerDeadlineExceeded(context.getGroup(), context.getName(), unitOfWork.getCriticality(), sourceKey);
-      throw new DeadlineExceededException(unitOfWork.getDeadline());
+      throw new DeadlineExceededException(unitOfWork.getDeadline(), unitOfWork.getCreationTime());
     }
   }
 

--- a/tw-context/src/main/java/com/transferwise/common/context/DurationFormatUtils.java
+++ b/tw-context/src/main/java/com/transferwise/common/context/DurationFormatUtils.java
@@ -1,0 +1,46 @@
+package com.transferwise.common.context;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import lombok.experimental.UtilityClass;
+
+/**
+ * Unfortunately Apache Common's DurationFormatUtils does not format milliseconds.
+ *
+ * <p>Package protected as not designed to be a generic class.
+ */
+@UtilityClass
+class DurationFormatUtils {
+
+  static String formatDuration(Duration duration) {
+    StringBuffer sb = new StringBuffer();
+
+    long milliseconds = duration.toMillis();
+    long hours = TimeUnit.MILLISECONDS.toHours(milliseconds);
+    milliseconds = milliseconds - TimeUnit.HOURS.toMillis(hours);
+
+    long minutes = TimeUnit.MILLISECONDS.toMinutes(milliseconds);
+    milliseconds = milliseconds - TimeUnit.MINUTES.toMillis(minutes);
+
+    long seconds = TimeUnit.MILLISECONDS.toSeconds(milliseconds);
+    milliseconds = milliseconds - TimeUnit.SECONDS.toMillis(seconds);
+
+    if (hours != 0) {
+      sb.append(hours).append(" hours ");
+    }
+    if (minutes != 0) {
+      sb.append(minutes).append(" minutes ");
+    }
+    if (seconds != 0) {
+      sb.append(seconds).append(" seconds ");
+    }
+    if (milliseconds != 0 || sb.length() == 0) {
+      sb.append(milliseconds).append(" milliseconds");
+    }
+    if (sb.charAt(sb.length() - 1) == ' ') {
+      return sb.substring(0, sb.length() - 1);
+    } else {
+      return sb.toString();
+    }
+  }
+}

--- a/tw-context/src/main/java/com/transferwise/common/context/UnitOfWork.java
+++ b/tw-context/src/main/java/com/transferwise/common/context/UnitOfWork.java
@@ -3,6 +3,7 @@ package com.transferwise.common.context;
 import com.transferwise.common.baseutils.clock.ClockHolder;
 import java.time.Instant;
 import lombok.Data;
+import lombok.NonNull;
 import lombok.experimental.Accessors;
 
 @Data
@@ -13,8 +14,11 @@ public class UnitOfWork {
 
   private Criticality criticality;
   private Instant deadline;
+  @NonNull
+  private Instant creationTime = ClockHolder.getClock().instant();
 
   public boolean hasDeadlinePassed() {
     return deadline != null && deadline.isBefore(ClockHolder.getClock().instant());
   }
+
 }

--- a/tw-context/src/test/java/com/transferwise/common/context/DurationFormatUtilsTest.java
+++ b/tw-context/src/test/java/com/transferwise/common/context/DurationFormatUtilsTest.java
@@ -1,0 +1,17 @@
+package com.transferwise.common.context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+public class DurationFormatUtilsTest {
+
+  @Test
+  void formattingWorks() {
+    assertThat(DurationFormatUtils.formatDuration(Duration.ofDays(10))).as("Hour is largest unit").isEqualTo("240 hours");
+    assertThat(DurationFormatUtils.formatDuration(Duration.ofMillis(1500))).isEqualTo("1 seconds 500 milliseconds");
+    assertThat(DurationFormatUtils.formatDuration(Duration.ofMinutes(61))).isEqualTo("1 hours 1 minutes");
+    assertThat(DurationFormatUtils.formatDuration(Duration.ofNanos(100000))).as("Millis is smallest unit").isEqualTo("0 milliseconds");
+  }
+}


### PR DESCRIPTION
Deadline exception contains also the duration taken in current UnitOfWork.

Example: 
"Deadline exceeded 3 seconds 1 milliseconds ago. Time taken in current unit of work was 5 seconds."