### PR TITLE
Avoid time flooring to millis.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 references:
   container_config: &container_config
     docker:
-      - image: arti.tw.ee/circle_openjdk11:latest
+      - image: docker.tw.ee/circle_openjdk11:latest
         user: circleci
     resource_class: medium
     environment:

--- a/tw-context/src/main/java/com/transferwise/common/context/DeadlineExceededException.java
+++ b/tw-context/src/main/java/com/transferwise/common/context/DeadlineExceededException.java
@@ -12,13 +12,13 @@ public class DeadlineExceededException extends RuntimeException {
   }
 
   private static String createMessage(Instant deadline, Instant unitOfWorkCreationTime) {
-    long sinceDeadlineExceededMillis = Math.max(0, TwContextClockHolder.getClock().millis() - deadline.toEpochMilli());
-    String formattedDeadline = DurationFormatUtils.formatDuration(Duration.ofMillis(sinceDeadlineExceededMillis));
+    Duration sinceDeadlineExceeded = Duration.between(deadline, TwContextClockHolder.getClock().instant());
+    String formattedDeadline = DurationFormatUtils.formatDuration(sinceDeadlineExceeded);
     if (unitOfWorkCreationTime == null) {
       return "Deadline exceeded " + formattedDeadline + " ago.";
     } else {
-      long durationMillis = Math.max(0, TwContextClockHolder.getClock().millis() - unitOfWorkCreationTime.toEpochMilli());
-      String formattedDuration = DurationFormatUtils.formatDuration(Duration.ofMillis(durationMillis));
+      Duration duration = Duration.between(unitOfWorkCreationTime, TwContextClockHolder.getClock().instant());
+      String formattedDuration = DurationFormatUtils.formatDuration(duration);
       return "Deadline exceeded " + formattedDeadline + " ago. Time taken in current unit of work was " + formattedDuration + ".";
     }
   }

--- a/tw-context/src/main/java/com/transferwise/common/context/DefaultTimeoutCustomizer.java
+++ b/tw-context/src/main/java/com/transferwise/common/context/DefaultTimeoutCustomizer.java
@@ -21,7 +21,7 @@ public class DefaultTimeoutCustomizer implements TimeoutCustomizer {
 
     Duration result;
     if (twContextProperties.getTimeoutMultiplier() != null) {
-      result = Duration.ofMillis((long) (timeout.toMillis() * twContextProperties.getTimeoutMultiplier()));
+      result = Duration.ofNanos((long) (timeout.toNanos() * twContextProperties.getTimeoutMultiplier()));
     } else {
       result = timeout;
     }

--- a/tw-context/src/main/java/com/transferwise/common/context/DefaultUnitOfWorkManager.java
+++ b/tw-context/src/main/java/com/transferwise/common/context/DefaultUnitOfWorkManager.java
@@ -89,7 +89,7 @@ public class DefaultUnitOfWorkManager implements UnitOfWorkManager {
 
     @Override
     public Builder deadline(Duration duration) {
-      this.deadline = Instant.ofEpochMilli(TwContextClockHolder.getClock().millis()).plus(duration);
+      this.deadline = TwContextClockHolder.getClock().instant().plus(duration);
       return this;
     }
 

--- a/tw-context/src/main/java/com/transferwise/common/context/UnitOfWork.java
+++ b/tw-context/src/main/java/com/transferwise/common/context/UnitOfWork.java
@@ -14,10 +14,10 @@ public class UnitOfWork {
   private Criticality criticality;
   private Instant deadline;
   @NonNull
-  private Instant creationTime = Instant.ofEpochMilli(TwContextClockHolder.getClock().millis());
+  private Instant creationTime = TwContextClockHolder.getClock().instant();
 
   public boolean hasDeadlinePassed() {
-    return deadline != null && deadline.isBefore(Instant.ofEpochMilli(TwContextClockHolder.getClock().millis()));
+    return deadline != null && deadline.isBefore(TwContextClockHolder.getClock().instant());
   }
 
 }


### PR DESCRIPTION
## Context

Going via milliseconds truncates the nano component of Instant. This leads to vairous weird results when trying to work out remaining time.
The use of millis was done as an optimisation, since getting the nano time is slightly more expensive, but in benchmarks the difference seems to be insignificant/noise.

### Changes

Use instants and "nano" precision methods.
It's still easy to make mistakes when calculating remaining time, but at least this removes some hazards...

## Checklist
- [x] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
