### PR TITLE
[APPENG-370] Convert existing docs to TechDocs format + add usage & contributing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,8 @@
 > Use the `@application-engineering-on-call` handle on Slack for help.
 ---
 
-Defines and owns important concepts of
-- entrypoints
-- unit of work
-- deadlines
-- criticality
-
-## Owner field
-
-Many applications have multiple owners - on endpoints, jobs and other units of work.
-
-It is useful to correlate Rollbar errors, logs and even metrics by specific owners.
-
-`com.transferwise.common.context.TwContextAttributeChangeListenerTest.ownerCanBeSetWhenNameIsChanged` describes how
-to make the application set the owner field.
-
-But for services, to set an owner it is recommended to use `tw-context-ownership-starter` module instead.
-Please consult with its [README](tw-context-ownership-starter/README.md) what it can do and how to use it.
+## 📚 Documentation
+Documentation can be found in the [docs](docs) directory or for Wisers, on the [developer portal](https://dev.tw.ee/docs/default/Component/tw-context).
 
 ## License
 Copyright 2021 TransferWise Ltd.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,3 @@
+# Contribution Guide
+To contribute to the library, you can either open an issue or create a pull request. Please ensure that you create unit tests for any new features you introduce and ensure that all tests are passing.
+Finally, please remember to update the [project's version](https://github.com/transferwise/tw-context/blob/master/gradle.properties) following [semantic versioning](https://semver.org/), and update the [CHANGELOG](https://github.com/transferwise/tw-context/blob/master/CHANGELOG.md) accordingly.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,19 @@
+# tw-context Documentation
+
+Defines and owns important concepts of
+- entrypoints
+- unit of work
+- deadlines
+- criticality
+
+## Owner field
+
+Many applications have multiple owners - on endpoints, jobs and other units of work.
+
+It is useful to correlate Rollbar errors, logs and even metrics by specific owners.
+
+`com.transferwise.common.context.TwContextAttributeChangeListenerTest.ownerCanBeSetWhenNameIsChanged` describes how
+to make the application set the owner field.
+
+But for services, to set an owner it is recommended to use `tw-context-ownership-starter` module instead.
+Please consult with its [README](https://github.com/transferwise/tw-context/blob/master/tw-context-ownership-starter/README.md) what it can do and how to use it.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -13,4 +13,4 @@ dependencies {
 }
 ```
 > Replace `<VERSION>` with the version of the library you want to use.
-> You can also use `tw-context-starter` which autoconfigures some Spring beans. Or `tw-context-ownership-starter`  if you want to automatically set the `TwContexts`'s `owner` attribute.
+> You can also use `tw-context-starter` which autoconfigures some Spring beans. Or `tw-context-ownership-starter` if you want to automatically set the `TwContexts`'s `owner` attribute.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,16 @@
+# Usage
+
+To use the library, first add the `mavenCentral` repository to your `repositories` block in your `build.gradle`:
+```groovy
+repositories {
+  mavenCentral()
+}
+```
+Then, add the `tw-context` library as a dependency in your `dependencies` block in your `build.gradle`:
+```groovy
+dependencies {
+  implementation 'com.transferwise.common:tw-context:<VERSION>'
+}
+```
+> Replace `<VERSION>` with the version of the library you want to use.
+> You can also use `tw-context-starter` which autoconfigures some Spring beans. Or `tw-context-ownership-starter`  if you want to automatically set the `TwContexts`'s `owner` attribute.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,0 +1,7 @@
+site_name: tw-context Documentation
+repo_url: https://github.com/transferwise/tw-context
+edit_uri: blob/master/docs/
+nav:
+  - Overview: index.md
+  - Usage: usage.md
+  - Contributing: contributing.md

--- a/tw-context-ownership-starter/README.md
+++ b/tw-context-ownership-starter/README.md
@@ -2,7 +2,7 @@
 
 An implementation to automatically set the  `TwContext`'s `owner` attribute, based on which entrypoint the code is running in.
 
-By default it is configured to use Github teams names as `owner` value.
+By default, it is configured to use GitHub teams names as `owner` value.
 
 Example configuration.
 ```yaml
@@ -12,4 +12,4 @@ tw-context:
       - "Jobs:testJob1:latam"
       - "Web:/v1/profile/1 (GET):profile-service"
     default-owner: "webapp-reliability"
-``` 
+```


### PR DESCRIPTION
## Context

Convert existing docs to TechDocs format + add usage & contributing guide, part of the library upgrade tickets that the application-engineering team is doing.

## Checklist
- [X] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
