### PR TITLE
[APPENG-763] Update matrix tests to run with SB 3.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,10 @@ jobs:
       max-parallel: 100
       matrix:
         spring_boot_version:
+          - 3.2.2
           - 3.1.2
           - 3.0.9
           - 2.7.14
-          - 2.6.15
     container:
       image: azul/zulu-openjdk:17
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2024-02-21
+
+### Changed
+* - Added support for Spring Boot 3.2.
+
 ## [1.0.0] - 2023-09-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 * - Added support for Spring Boot 3.2.
+    - Updated dependencies.
 
 ## [1.0.0] - 2023-09-22
 

--- a/build.common.gradle
+++ b/build.common.gradle
@@ -85,6 +85,10 @@ java {
     withJavadocJar()
 }
 
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs.add("-parameters")
+}
+
 jar {
     manifest {
         attributes(

--- a/build.common.gradle
+++ b/build.common.gradle
@@ -85,10 +85,6 @@ java {
     withJavadocJar()
 }
 
-tasks.withType(JavaCompile).configureEach {
-    options.compilerArgs.add("-parameters")
-}
-
 jar {
     manifest {
         attributes(

--- a/build.libraries.gradle
+++ b/build.libraries.gradle
@@ -4,9 +4,9 @@ ext {
     libraries = [
             // version defined
             commonsText                     : 'org.apache.commons:commons-text:1.10.0',
-            guava                           : 'com.google.guava:guava:32.1.2-jre',
+            guava                           : 'com.google.guava:guava:33.0.0-jre',
             springBootDependencies          : "org.springframework.boot:spring-boot-dependencies:${springBootVersion}",
-            twBaseUtils                     : "com.transferwise.common:tw-base-utils:1.9.0",
+            twBaseUtils                     : "com.transferwise.common:tw-base-utils:1.12.3",
 
             // versions managed by spring-boot-dependencies platform
             assertjCore                     : 'org.assertj:assertj-core',

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.0
+version=1.0.1


### PR DESCRIPTION
## Context

Wise is now supporting Spring Boot 3.2 so matrix tests need to be updated to run with the new version.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 


## Details from ticket: [APPENG-763](https://transferwise.atlassian.net/browse/APPENG-763)

### Update platform libraries matrix tests to run with boot 3.2

>Keeping track of all the libraries that have received support for Boot 3.2 here:
>[https://docs.google.com/spreadsheets/d/1cogv7V6ofZv1urcBYYrj91f3VzKg-e92DltiiRgqndc/edit#gid=242339130|https://docs.google.com/spreadsheets/d/1cogv7V6ofZv1urcBYYrj91f3VzKg-e92DltiiRgqndc/edit#gid=242339130|smart-link] 


[APPENG-763]: https://transferwise.atlassian.net/browse/APPENG-763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ