### PR TITLE
Remove Speed team from TwTeam

### DIFF
--- a/tw-context-ownership-starter/src/main/java/com/transferwise/common/context/ownership/TwTeam.java
+++ b/tw-context-ownership-starter/src/main/java/com/transferwise/common/context/ownership/TwTeam.java
@@ -53,7 +53,6 @@ public enum TwTeam {
   SECURITY("security"),
   SEND_MONEY("send-money"),
   SMB("smb"),
-  SPEED("speed"),
   TREASURY("treasury"),
   USD("usd"),
   VERIFICATION("verification"),


### PR DESCRIPTION
## Context

Speed team doesn't exist, its services are mostly redistributed amongst pp-transfer and send-money

## Checklist
- [X] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
