### PR TITLE
Adding ThreadLocalAccessor for TwContext

### DIFF
--- a/build.libraries.gradle
+++ b/build.libraries.gradle
@@ -7,6 +7,7 @@ ext {
             guava                           : 'com.google.guava:guava:33.0.0-jre',
             springBootDependencies          : "org.springframework.boot:spring-boot-dependencies:${springBootVersion}",
             twBaseUtils                     : "com.transferwise.common:tw-base-utils:1.12.3",
+            micrometerContextPropagation    : "io.micrometer:context-propagation:1.1.2",
 
             // versions managed by spring-boot-dependencies platform
             assertjCore                     : 'org.assertj:assertj-core',

--- a/tw-context/build.gradle
+++ b/tw-context/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation libraries.slf4jApi
     implementation libraries.guava
     implementation libraries.twBaseUtils
+    implementation libraries.micrometerContextPropagation
 
     api libraries.micrometerCore
 }

--- a/tw-context/src/main/java/com/transferwise/common/context/TwContext.java
+++ b/tw-context/src/main/java/com/transferwise/common/context/TwContext.java
@@ -12,6 +12,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
+import io.micrometer.context.ContextRegistry;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -35,8 +36,13 @@ public class TwContext {
   private static final ThreadLocal<Optional<TwContext>> contextTl = new ThreadLocal<>();
   private static final List<TwContextExecutionInterceptor> interceptors = new CopyOnWriteArrayList<>();
   private static final List<TwContextAttributePutListener> attributePutListeners = new CopyOnWriteArrayList<>();
-  private static final TwContext ROOT_CONTEXT = new TwContext(null, true);
   private static final RateLimiter throwableLoggingRateLimiter = RateLimiter.create(2);
+
+  static final TwContext ROOT_CONTEXT = new TwContext(null, true);
+
+  static {
+    ContextRegistry.getInstance().registerThreadLocalAccessor(new TwContextThreadLocalAccessor());
+  }
 
   public static TwContext current() {
     Optional<TwContext> twContext = contextTl.get();

--- a/tw-context/src/main/java/com/transferwise/common/context/TwContextThreadLocalAccessor.java
+++ b/tw-context/src/main/java/com/transferwise/common/context/TwContextThreadLocalAccessor.java
@@ -1,0 +1,28 @@
+package com.transferwise.common.context;
+
+import io.micrometer.context.ThreadLocalAccessor;
+
+import static com.transferwise.common.context.UnitOfWork.TW_CONTEXT_KEY;
+
+public class TwContextThreadLocalAccessor implements ThreadLocalAccessor<TwContext> {
+
+  @Override
+  public Object key() {
+    return TW_CONTEXT_KEY;
+  }
+
+  @Override
+  public TwContext getValue() {
+    return TwContext.current();
+  }
+
+  @Override
+  public void setValue(TwContext context) {
+    context.attach();
+  }
+
+  @Override
+  public void reset() {
+    TwContext.ROOT_CONTEXT.attach();
+  }
+}


### PR DESCRIPTION
## Context

Adding ThreadLocalAccessor for TwContext so it's available in Reactor operations
Reactor uses context-propagation API to set and restore thread locals

## Checklist
- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
