### PR TITLE
Add durations as properties to DeadlineExceededException

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
           tar -zcvf all-test-reports-${{ matrix.spring_boot_version }}.tar.gz **/build/reports
         if: always()
       - name: "Store test results"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: all-test-reports-${{ matrix.spring_boot_version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.3] - 2025-05-05
+## [2.1.0] - 2025-05-05
 
 ### Changed
 * Add durations as properties to DeadlineExceededException

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 2025-05-05
+
+### Changed
+* Add durations as properties to DeadlineExceededException
+
 ## [2.0.2] - 2024-12-04
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.0.2
+version=2.0.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.0.3
+version=2.1.0

--- a/tw-context-starter/src/test/java/com/transferwise/common/context/ApplicationIntTest.java
+++ b/tw-context-starter/src/test/java/com/transferwise/common/context/ApplicationIntTest.java
@@ -130,6 +130,8 @@ public class ApplicationIntTest {
     assertThat(new DeadlineExceededException(deadline).getMessage()).isEqualTo("Deadline exceeded 3 seconds 1 milliseconds ago.");
     assertThat(new DeadlineExceededException(deadline, start).getMessage())
         .isEqualTo("Deadline exceeded 3 seconds 1 milliseconds ago. Time taken in current unit of work was 5 seconds.");
+    assertThat(new DeadlineExceededException(deadline, start).getSinceDeadlineExceededMillis() == 3001).isTrue();
+    assertThat(new DeadlineExceededException(deadline, start).getDurationMillis() == 5000).isTrue();
 
     testClock.set(start);
     assertThatThrownBy(() -> unitOfWorkManager.createUnitOfWork().deadline(deadline).toContext().execute(() -> {

--- a/tw-context/src/main/java/com/transferwise/common/context/DeadlineExceededException.java
+++ b/tw-context/src/main/java/com/transferwise/common/context/DeadlineExceededException.java
@@ -1,33 +1,46 @@
 package com.transferwise.common.context;
 
+import lombok.Data;
 import java.time.Duration;
 import java.time.Instant;
 
+@Data
 public class DeadlineExceededException extends RuntimeException {
 
   static final long serialVersionUID = 1L;
 
-  public DeadlineExceededException(Instant deadline, Instant unitOfWorkCreationTime) {
-    super(createMessage(deadline, unitOfWorkCreationTime));
-  }
-
-  private static String createMessage(Instant deadline, Instant unitOfWorkCreationTime) {
-    long sinceDeadlineExceededMillis = Math.max(0, TwContextClockHolder.getClock().millis() - deadline.toEpochMilli());
-    String formattedDeadline = DurationFormatUtils.formatDuration(Duration.ofMillis(sinceDeadlineExceededMillis));
-    if (unitOfWorkCreationTime == null) {
-      return "Deadline exceeded " + formattedDeadline + " ago.";
-    } else {
-      long durationMillis = Math.max(0, TwContextClockHolder.getClock().millis() - unitOfWorkCreationTime.toEpochMilli());
-      String formattedDuration = DurationFormatUtils.formatDuration(Duration.ofMillis(durationMillis));
-      return "Deadline exceeded " + formattedDeadline + " ago. Time taken in current unit of work was " + formattedDuration + ".";
-    }
-  }
+  private final long sinceDeadlineExceededMillis;
+  private final long durationMillis;
 
   public DeadlineExceededException(Instant deadline) {
     this(deadline, null);
   }
 
-  public DeadlineExceededException(String message) {
-    super(message);
+  public DeadlineExceededException(Instant deadline, Instant unitOfWorkCreationTime) {
+    super(createMessage(deadline, unitOfWorkCreationTime));
+    sinceDeadlineExceededMillis = sinceDeadlineExceededMillis(deadline);
+    durationMillis = durationMillis(unitOfWorkCreationTime);
+  }
+
+  private static String createMessage(Instant deadline, Instant unitOfWorkCreationTime) {
+    long sinceDeadlineExceededMillis = sinceDeadlineExceededMillis(deadline);
+    String formattedDeadline = DurationFormatUtils.formatDuration(Duration.ofMillis(sinceDeadlineExceededMillis));
+    if (unitOfWorkCreationTime == null) {
+      return "Deadline exceeded " + formattedDeadline + " ago.";
+    } else {
+      long durationMillis = durationMillis(unitOfWorkCreationTime);
+      String formattedDuration = DurationFormatUtils.formatDuration(Duration.ofMillis(durationMillis));
+      return "Deadline exceeded " + formattedDeadline + " ago. Time taken in current unit of work was " + formattedDuration + ".";
+    }
+  }
+
+  private static long sinceDeadlineExceededMillis(Instant deadline) {
+    return Math.max(0, TwContextClockHolder.getClock().millis() - deadline.toEpochMilli());
+  }
+
+  private static long durationMillis(Instant unitOfWorkCreationTime) {
+    return unitOfWorkCreationTime == null
+        ? 0
+        : Math.max(0, TwContextClockHolder.getClock().millis() - unitOfWorkCreationTime.toEpochMilli());
   }
 }

--- a/tw-context/src/main/java/com/transferwise/common/context/DeadlineExceededException.java
+++ b/tw-context/src/main/java/com/transferwise/common/context/DeadlineExceededException.java
@@ -9,8 +9,12 @@ public class DeadlineExceededException extends RuntimeException {
 
   static final long serialVersionUID = 1L;
 
-  private final long sinceDeadlineExceededMillis;
-  private final long durationMillis;
+  private long sinceDeadlineExceededMillis;
+  private long durationMillis;
+
+  public DeadlineExceededException(String message) {
+    super(message);
+  }
 
   public DeadlineExceededException(Instant deadline) {
     this(deadline, null);

--- a/tw-context/src/main/java/com/transferwise/common/context/DeadlineExceededException.java
+++ b/tw-context/src/main/java/com/transferwise/common/context/DeadlineExceededException.java
@@ -1,8 +1,8 @@
 package com.transferwise.common.context;
 
-import lombok.Data;
 import java.time.Duration;
 import java.time.Instant;
+import lombok.Data;
 
 @Data
 public class DeadlineExceededException extends RuntimeException {


### PR DESCRIPTION
## Context
Add durations as properties to DeadlineExceededException

would use those in rollbar filter, to reduce noise 

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
