### PR TITLE
remove data annotation from DeadlineExceededException.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.2] - 2025-07-09
+
+### Changed
+* remove Data annotation from DeadlineExceededException.
+
 ## [2.1.1] - 2025-06-19
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.1.1
+version=2.1.2

--- a/tw-context/src/main/java/com/transferwise/common/context/DeadlineExceededException.java
+++ b/tw-context/src/main/java/com/transferwise/common/context/DeadlineExceededException.java
@@ -2,9 +2,9 @@ package com.transferwise.common.context;
 
 import java.time.Duration;
 import java.time.Instant;
-import lombok.Data;
+import lombok.Getter;
 
-@Data
+@Getter
 public class DeadlineExceededException extends RuntimeException {
 
   static final long serialVersionUID = 1L;


### PR DESCRIPTION
## Context
remove data annotation from DeadlineExceededException.
Replace it with getter. 

## Checklist
- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
