### PR TITLE
PAT-4885: Provide custom URL for nexus plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.3] - 2025-07-29
+
+### Changed
+* Updated nexus plugin to read url from env variable.
+
 ## [2.1.2] - 2025-07-09
 
 ### Changed

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ group = "com.transferwise.common"
 nexusPublishing {
     repositories {
         sonatype {
-            nexusUrl.set(uri(System.getenv("MAVEN_URL")))
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2"))
             username = System.getenv("SONATYPE_USER")
             password = System.getenv("SONATYPE_PASSWORD")
         }

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,6 @@ group = "com.transferwise.common"
 nexusPublishing {
     repositories {
         sonatype {
-            nexusUrl.set(uri(System.getenv("MAVEN_URL")))
             username = System.getenv("SONATYPE_USER")
             password = System.getenv("SONATYPE_PASSWORD")
         }

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ group = "com.transferwise.common"
 nexusPublishing {
     repositories {
         sonatype {
+            nexusUrl.set(uri(System.getenv("MAVEN_URL")))
             username = System.getenv("SONATYPE_USER")
             password = System.getenv("SONATYPE_PASSWORD")
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.1.2
+version=2.1.3


### PR DESCRIPTION
## Context

<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->

TLDR: OSSRH reached EOL, testing publish with new URL provided by Sonatype 

This pull request includes a version update and a changelog entry for the project. The changes are minor and primarily involve documentation and versioning updates.

- [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R12): Added an entry for version `2.1.3`, documenting the update to the nexus plugin to read the URL from an environment variable.
- [`gradle.properties`](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L1-R1): Updated the project version from `2.1.2` to `2.1.3`.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
